### PR TITLE
支持使用conan作为包管理器

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ cmake-*
 [Bb]uild*
 install
 compile_commands.json
+CMakeUserPresets.json

--- a/README-zh.md
+++ b/README-zh.md
@@ -115,6 +115,13 @@ cmake -B build
 cmake --build build
 cmake --install build
 ```
+使用conan作为包管理器：
+```bash
+conan install . --build=missing -s build_type=Release
+cmake --preset conan-release
+cmake --build build/Release
+cmake --install build/Release
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ cmake -B build
 cmake --build build
 cmake --install build
 ```
+Use conan as the package manager:
+```bash
+conan install . --build=missing -s build_type=Release
+cmake --preset conan-release
+cmake --build build/Release
+cmake --install build/Release
+```
 
 ---
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,11 @@
+[requires]
+asio/1.36.0
+spdlog/1.15.3
+libusb/1.0.26
+libevdev/1.13.1
+[generators]
+CMakeDeps
+CMakeToolchain
+PkgConfigDeps
+[layout]
+cmake_layout


### PR DESCRIPTION
**开发者你好：**

感谢你创建了这个优秀的项目。

在本地构建时，我发现手动或通过系统包管理器安装第三方依赖较为繁琐，而且我这里出现了一些问题，促使我寻找其他解决方案。

为了解决这个问题，此 PR 引入了 Conan 作为包管理器，通过 conanfile.txt 声明了所有必需的依赖项。现在，开发者可以通过 Conan 自动获取并配置所有第三方库，简化了项目的初次构建流程。

此次改动是非侵入性的，在原本构建流程的基础上提供了新的选择，并且在文档中对操作流程进行了说明。

新的构建与测试流程如下，已验证工作正常：
```bash
usbipdcpp on  main [!?] via △ v3.31.6 
❯ conan install . --build=missing -s build_type=Release

======== Input profiles ========
Profile host:
[settings]
arch=x86_64
build_type=Release
compiler=gcc
compiler.cppstd=gnu20
compiler.cstd=gnu11
compiler.libcxx=libstdc++11
compiler.version=15
os=Linux
[conf]
tools.build:compiler_executables={'c': 'gcc', 'cpp': 'g++'}
tools.cmake.cmaketoolchain:generator=Ninja

Profile build:
[settings]
arch=x86_64
build_type=Debug
compiler=gcc
compiler.cppstd=gnu20
compiler.cstd=gnu11
compiler.libcxx=libstdc++11
compiler.version=15
os=Linux
[conf]
tools.build:compiler_executables={'c': 'gcc', 'cpp': 'g++'}
tools.cmake.cmaketoolchain:generator=Ninja


======== Computing dependency graph ========
Graph root
    conanfile.txt: /home/hao/projects/usbipdcpp/conanfile.txt
Requirements
    asio/1.36.0#75a50dae6e50af10cfb2150286b7df39 - Cache
    fmt/11.2.0#579bb2cdf4a7607621beea4eb4651e0f - Cache
    libevdev/1.13.1#0153131e76a1466ee1586ccbc4c10ea4 - Cache
    libudev/system#6aaa8ab03cabc6f3131bac21b7ce1e8a - Cache
    libusb/1.0.26#c0c00750b383839aa140a0be628d552c - Cache
    spdlog/1.15.3#3ca0e9e6b83af4d0151e26541d140c86 - Cache
Build requirements
    meson/1.2.2#21b73818ba96d9eea465b310b5bbc993 - Cache
    ninja/1.13.1#294f8721dbcde145674f7ba44994700e - Cache
Resolved version ranges
    ninja/[>=1.10.2 <2]: ninja/1.13.1

======== Computing necessary packages ========
Connecting to remote 'conancenter' anonymously
fmt/11.2.0: Main binary package 'd9a4f8ea86a76190d4c71f92bf1c4dc3c9c9d74d' missing
fmt/11.2.0: Checking 11 compatible configurations
fmt/11.2.0: Found compatible package '4833ef63bd83f13faceda52fc47debc2a79a5f38': compiler.cppstd=gnu17
spdlog/1.15.3: Main binary package 'eeb7f4a5244a55c789aaa3c7b24016a34ae8978b' missing
spdlog/1.15.3: Checking 11 compatible configurations
spdlog/1.15.3: Found compatible package '3dcfe292dd6ab5f7171c1b0f1de13499e2ffd07a': compiler.cppstd=gnu17
Requirements
    asio/1.36.0#75a50dae6e50af10cfb2150286b7df39:da39a3ee5e6b4b0d3255bfef95601890afd80709#c02fdd2b35b8e2b48197b1749056e852 - Cache
    fmt/11.2.0#579bb2cdf4a7607621beea4eb4651e0f:4833ef63bd83f13faceda52fc47debc2a79a5f38#90e3b5a0c857f632acfc646ffb46c11e - Cache
    libevdev/1.13.1#0153131e76a1466ee1586ccbc4c10ea4:5172837b05c2f087e99d128455aac37041416625#8c51bd7a808aa850638625c4fdeba8d0 - Cache
    libudev/system#6aaa8ab03cabc6f3131bac21b7ce1e8a:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ba8627bd47edc3a501e8f0eb9a79e5e - Cache
    libusb/1.0.26#c0c00750b383839aa140a0be628d552c:16b28696edf016ad9106bc4c8c6972790ac8ae9c#72e00b0c1e9f5ff19cc752f876e37546 - Cache
    spdlog/1.15.3#3ca0e9e6b83af4d0151e26541d140c86:3dcfe292dd6ab5f7171c1b0f1de13499e2ffd07a#5aadbe929d27088011757ecd5c905ac3 - Cache
Build requirements
Skipped binaries
    meson/1.2.2, ninja/1.13.1
systemd-devel-257.7-1.fc42.x86_64
libudev/system: System requirements:  already installed

======== Installing packages ========
asio/1.36.0: Already installed! (1 of 6)
fmt/11.2.0: Already installed! (2 of 6)
libudev/system: Already installed! (3 of 6)
libevdev/1.13.1: Already installed! (4 of 6)
libusb/1.0.26: Already installed! (5 of 6)
spdlog/1.15.3: Already installed! (6 of 6)

======== Finalizing install (deploy, generators) ========
conanfile.txt: Writing generators to /home/hao/projects/usbipdcpp/build/Release/generators
conanfile.txt: Generator 'CMakeDeps' calling 'generate()'
conanfile.txt: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(asio)
    find_package(spdlog)
    find_package(libusb)
    find_package(libevdev)
    target_link_libraries(... asio::asio spdlog::spdlog libusb::libusb libevdev::libevdev)
conanfile.txt: Generator 'CMakeToolchain' calling 'generate()'
conanfile.txt: CMakeToolchain generated: conan_toolchain.cmake
conanfile.txt: CMakeToolchain: Preset 'conan-release' added to CMakePresets.json.
    (cmake>=3.23) cmake --preset conan-release
    (cmake<3.23) cmake <path> -G Ninja -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake  -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=Release
conanfile.txt: CMakeToolchain generated: /home/hao/projects/usbipdcpp/build/Release/generators/CMakePresets.json
conanfile.txt: CMakeToolchain generated: /home/hao/projects/usbipdcpp/CMakeUserPresets.json
conanfile.txt: Generator 'PkgConfigDeps' calling 'generate()'
conanfile.txt: Generating aggregated env files
conanfile.txt: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
Install finished successfully

usbipdcpp on  main [!?] via △ v3.31.6 
❯ cmake --preset conan-release -DCMAKE_INSTALL_PREFIX=/home/hao/projects/tools/cmake_installed_lib/usbipdcpp/
Preset CMake variables:

  CMAKE_BUILD_TYPE="Release"
  CMAKE_POLICY_DEFAULT_CMP0091="NEW"
  CMAKE_TOOLCHAIN_FILE:FILEPATH="generators/conan_toolchain.cmake"

-- Using Conan toolchain: /home/hao/projects/usbipdcpp/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: C++ Standard 20 with extensions ON
-- The C compiler identification is GNU 15.2.1
-- The CXX compiler identification is GNU 15.2.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/lib64/ccache/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/lib64/ccache/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Warning: Standard CMAKE_CXX_STANDARD value defined in conan_toolchain.cmake to 20 has been modified to 23 by /home/hao/projects/usbipdcpp/CMakeLists.txt
-- Conan: Target declared 'asio::asio'
-- Conan: Component target declared 'spdlog::spdlog'
-- Conan: Component target declared 'fmt::fmt'
-- Found PkgConfig: /usr/bin/pkg-config (found version "2.3.0")
-- Checking for module 'libusb-1.0'
--   Found libusb-1.0, version 1.0.26
-- Checking for module 'libevdev'
--   Found libevdev, version 1.13.1
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Configuring done (0.9s)
-- Generating done (0.0s)
-- Build files have been written to: /home/hao/projects/usbipdcpp/build/Release

usbipdcpp on  main [!?] via △ v3.31.6 
❯ cmake --build build/Release
[30/30] Linking CXX executable test_protocol

usbipdcpp on  main [!?] via △ v3.31.6 took 12s 
❯ cmake --install build/Release
-- Install configuration: "Release"
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/DeviceHandler
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/DeviceHandler/DeviceHandler.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/DeviceHandler/SimpleVirtualDeviceHandler.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/DeviceHandler/VirtualDeviceHandler.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/InterfaceHandler
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/InterfaceHandler/HidVirtualInterfaceHandler.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/InterfaceHandler/InterfaceHandler.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/InterfaceHandler/VirtualInterfaceHandler.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/Server.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/Session.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/SetupPacket.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/StringPool.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/Version.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/constant.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/device.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/endpoint.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/interface.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/libusb_handler
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/libusb_handler/LibusbDeviceHandler.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/libusb_handler/LibusbServer.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/libusb_handler/tools.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/network.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/protocol.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/type.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/include/utils.h
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/lib/cmake/usbipdcpp/usbipdcppTargets.cmake
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/lib/cmake/usbipdcpp/usbipdcppTargets-release.cmake
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/lib/libusbipdcpp.a
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/lib/libusbipdcpp_libusb.a
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/lib/cmake/usbipdcpp/usbipdcppConfig.cmake
-- Installing: /home/hao/projects/tools/cmake_installed_lib/usbipdcpp/lib/cmake/usbipdcpp/usbipdcppConfigVersion.cmake

usbipdcpp on  main [!?] via △ v3.31.6 
❯ 
```

**希望能合并这个改进，谢谢！**